### PR TITLE
new default database name 'laravel'

### DIFF
--- a/src/Console/Commands/CraftableInitializeEnv.php
+++ b/src/Console/Commands/CraftableInitializeEnv.php
@@ -59,7 +59,7 @@ class CraftableInitializeEnv extends Command
      */
     private function getDbSettings(): void
     {
-        if (env('DB_DATABASE') === 'homestead' && $this->input->isInteractive()) {
+        if ((env('DB_DATABASE') === 'homestead' || env('DB_DATABASE') === 'laravel') && $this->input->isInteractive()) {
             $dbConnection = $this->choice('What database driver do you use?', ['mysql', 'pgsql'], 1);
             if (!empty($dbConnection)) {
                 $this->strReplaceInFile(


### PR DESCRIPTION
Default database name changed from 'homestead' to 'laravel', reference [this commit](https://github.com/laravel/laravel/commit/6f3d68f67f3dab0e0d853719696ede8dfd9cc4e1#diff-cbfd64a28982a1818f2b5f16e7f9d634)